### PR TITLE
Fixes ReachableMarkingsOfPetriNet initial list not set error

### DIFF
--- a/gap/states.gi
+++ b/gap/states.gi
@@ -20,6 +20,7 @@ InstallGlobalFunction(ReachableMarkingsOfPetriNet,
 function(petrinet,precond,postcond)
 local resultset, base,nbase, numoftransitions,i,j,nelem;
   numoftransitions := NumberOfTransitionsOfPetriNet(petrinet);
+  Sort(petrinet.initial); # ensure initial is a Set
   resultset := petrinet.initial;
   base := petrinet.initial;
   while not IsEmpty(base) do


### PR DESCRIPTION
Calls sort method on `petrinet.initial` to ensure that it satisfies set properties so that `AddSet` can be used. Fixes #3 