### PR TITLE
Generate descriptive petrinet state names

### DIFF
--- a/gap/display.gi
+++ b/gap/display.gi
@@ -1,5 +1,6 @@
 ###OUTPUTTING, DISPLAYING PETRI NETS############################################
 
+# Tokens + place name for each place in a state
 PetriNetDescriptiveStateNames := function(petrinet)
   local statenames, state, name, place;
   statenames := [];
@@ -13,6 +14,20 @@ PetriNetDescriptiveStateNames := function(petrinet)
         name := Concatenation(name, String(state[place]));
       fi;
       name := Concatenation(name, petrinet.places[place]);
+    od;
+    Add(statenames, name);
+  od;
+  return statenames;
+end;
+
+# Number of tokens concatenated for each place in a state
+PetriNetCondensedStateNames := function(petrinet)
+  local statenames, state, name, place;
+  statenames := [];
+  for state in petrinet.states do
+    name := "";
+    for place in [1..Size(state)] do
+      name := Concatenation(name, String(state[place]));
     od;
     Add(statenames, name);
   od;
@@ -79,6 +94,8 @@ function(petrinet,name, precond,postcond, ispartial)
   AppendTo(statelistfile,"];\n");
   if "places" in RecNames(petrinet) then
     petrinet.statenames := PetriNetDescriptiveStateNames(petrinet);
+  else
+    petrinet.statenames := PetriNetCondensedStateNames(petrinet);
   fi;
   return result;
 end);

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -1,5 +1,24 @@
 ###OUTPUTTING, DISPLAYING PETRI NETS############################################
 
+PetriNetDescriptiveStateNames := function(petrinet)
+  local statenames, state, name, place;
+  statenames := [];
+  for state in petrinet.states do
+    name := "";
+    for place in [1..Size(state)] do
+      if state[place] = 0 then
+        continue;
+      fi;
+      if state[place] <> 1 then
+        name := Concatenation(name, String(state[place]));
+      fi;
+      name := Concatenation(name, petrinet.places[place]);
+    od;
+    Add(statenames, name);
+  od;
+  return statenames;
+end;
+
 InstallGlobalFunction(DumpPetriNet, 
 function(petrinet,name, precond,postcond, ispartial)
   local i,numoftrans, numofstates, gensfile, strm,symbolfile, statesfile, namelookup, result,t,statelistfile,symbollistfile;
@@ -58,6 +77,9 @@ function(petrinet,name, precond,postcond, ispartial)
       if i < numofstates then AppendTo(statelistfile,","); fi;
   od;
   AppendTo(statelistfile,"];\n");
+  if "places" in RecNames(petrinet) then
+    petrinet.statenames := PetriNetDescriptiveStateNames(petrinet);
+  fi;
   return result;
 end);
 

--- a/gap/states.gi
+++ b/gap/states.gi
@@ -12,6 +12,7 @@ end);
 #just the direct product
 InstallGlobalFunction(AllGlobalMarkingsOfPetriNet, 
 function(petrinet)
+local output, states, i;
   if "condition" in RecNames(petrinet) then
     states := EnumeratorOfCartesianProduct(List(petrinet.capacity, x->[0..x]));
     output := [];


### PR DESCRIPTION
resolves #8 

After calling `DumpPetriNet`, the descriptive state names can be accessed via the `statenames` component of the petrinet record. 