### PR TITLE
Checks and warnings for petrinet.condition

### DIFF
--- a/gap/petrinet.gi
+++ b/gap/petrinet.gi
@@ -7,11 +7,11 @@
 
 InstallGlobalFunction(GetTransformationOfPetriNetTransition, 
 function(petrinet, transition, precond, postcond,ispartial)
-  local i,j,numofplaces, state, counter, maxstate, tlist, transientstate,lookup, inhibited;
+  local i,j,numofplaces, state, counter, maxstate, tlist, transientstate,lookup, inhibited, marking;
   numofplaces := NumberOfPlacesOfPetriNet(petrinet);
 
   if not ("states" in RecNames(petrinet)) then 
-      CalculateStatesOfPetriNet(petrinet,precond,postcond);
+      CalculateStatesOfPetriNet(petrinet,precond,postcond,ispartial);
   fi;
   maxstate := Size(petrinet.states);
 
@@ -38,7 +38,13 @@ function(petrinet, transition, precond, postcond,ispartial)
       od;
       if (not inhibited) then
         #when it is not inhibited
-        tlist[i] := lookup[ExecutePetriNetTransition(petrinet,transition,state,precond,postcond)];
+        marking := lookup[ExecutePetriNetTransition(petrinet,transition,state,precond,postcond)];
+        if (marking = fail) and (ispartial) then
+          # go to garbage state if transition goes outside of allowable states
+          tlist[i] := maxstate + 1;
+        else
+          tlist[i] := marking;
+        fi;
       else
         #it is inhibited, so it is the identity
         tlist[i] := i;

--- a/gap/states.gi
+++ b/gap/states.gi
@@ -1,10 +1,17 @@
 # if initial states are given only reachable states are calculated
 InstallGlobalFunction(CalculateStatesOfPetriNet, 
-  function(petrinet,precond,postcond)
+  function(petrinet,precond,postcond,ispartial)
   if IsEmpty(petrinet.initial) then
-    petrinet.states := AllGlobalMarkingsOfPetriNet(petrinet);
+    if "condition" in RecNames(petrinet) then
+      # set initial to be all possible states that satisfy the condition
+      petrinet.initial := AllGlobalMarkingsOfPetriNet(petrinet);
+      # calculate all reachable states from the generated initial states
+      petrinet.states := ReachableMarkingsOfPetriNet(petrinet,precond,postcond,ispartial);
+    else
+      petrinet.states := AllGlobalMarkingsOfPetriNet(petrinet);
+    fi;
   else
-    petrinet.states := ReachableMarkingsOfPetriNet(petrinet,precond,postcond);
+    petrinet.states := ReachableMarkingsOfPetriNet(petrinet,precond,postcond,ispartial);
   fi;
   return petrinet;
 end);
@@ -12,6 +19,7 @@ end);
 #just the direct product
 InstallGlobalFunction(AllGlobalMarkingsOfPetriNet, 
 function(petrinet)
+local output, states, i;
   if "condition" in RecNames(petrinet) then
     states := EnumeratorOfCartesianProduct(List(petrinet.capacity, x->[0..x]));
     output := [];
@@ -28,19 +36,49 @@ end);
 
 # basically a breadth-first search
 InstallGlobalFunction(ReachableMarkingsOfPetriNet, 
-function(petrinet,precond,postcond)
+function(petrinet,precond,postcond,ispartial)
 local resultset, base,nbase, numoftransitions,i,j,nelem;
   numoftransitions := NumberOfTransitionsOfPetriNet(petrinet);
+  
   Sort(petrinet.initial); # ensure initial is a Set
-  resultset := petrinet.initial;
-  base := petrinet.initial;
+  # check if initial states satisfy condition
+  if "condition" in RecNames(petrinet) then
+    for i in [1..Size(petrinet.initial)] do
+      # print warning if a state does not satisfy petrinet.condition
+      if not petrinet.condition(petrinet.initial[i]) then
+        Print(Concatenation("WARNING: Initial state: ",
+                            String(petrinet.initial[i]),
+                            " that does not satisfy petrinet.condition.\n"));
+      fi;
+    od;
+  fi;
+  resultset := ShallowCopy(petrinet.initial);
+  base := ShallowCopy(petrinet.initial);
   while not IsEmpty(base) do
     nbase:= [];
     for i in [1..numoftransitions] do 
       for j in [1..Size(base)] do
-        #here are the new elements generated
+        # get new marking by applying transition i to state base[j]
         nelem := ExecutePetriNetTransition(petrinet,i,base[j],precond,postcond);
         if not (nelem in resultset) then
+          if "condition" in RecNames(petrinet) then
+            # If new marking does not satisfy petrinet.condition
+            if not petrinet.condition(nelem) then
+              if ispartial then
+                # If ispartial is true, don't allow new marking and skip
+                Print(Concatenation("WARNING: Found reachable state: ",
+                                    String(nelem),
+                                    " that does not satisfy petrinet.condition. ",
+                                    "Disallow and go to garbage state.\n"));
+                continue;
+              else
+                # Otherwise, allow marking anyway
+                Print(Concatenation("WARNING: Added reachable marking: ", 
+                                    String(nelem), 
+                                    " that does not satisfy petrinet.condition.\n"));
+              fi;
+            fi;   
+          fi;
           AddSet(resultset,nelem);
           Add(nbase,nelem);
         fi;


### PR DESCRIPTION
Resolves #7 

`petrinet.initial` is specified
- check if all initial states satisfy condition. if not, give warning but continue
- find all states reachable from initial list
- if a state in initial does not satisfy condition, give warning
- when a new state is found, if condition is not satisfied:
    - go to garbage state if ispartial is specified
    - otherwise, allow those states
- in both cases, give appropriate warning

`petrinet.initial` is empty
- use `petrinet.condition` to set `petrinet.intial` to all possible states that satisfy the condition
- do as above (as if initial is specified)

_Originally posted by @erickque in https://github.com/egri-nagy/pn2a/issues/7#issuecomment-512901525_